### PR TITLE
Add NLTK to frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,7 @@ List of resources and tools developed with focus on Portuguese.
 
 ## Frameworks
 - [nlpnet](http://nilc.icmc.usp.br/nlpnet/)
+- [NLTK](https://www.nltk.org/howto/portuguese_en.html)
 - [polyglot](https://github.com/aboSamoor/polyglot)
 - [spaCy](https://spacy.io/models/pt)
 - [Stanza NLP](https://stanfordnlp.github.io/stanza/available_models.html)


### PR DESCRIPTION
my humble contribution to this fantastic list:

- add [nltk](https://www.nltk.org) to frameworks. nltk includes multiple tools for working with Portuguese text (Brazilian or otherwise), such as easy access to corpora, stemmers, and so on.